### PR TITLE
game stats

### DIFF
--- a/srcs/data/django/main/models.py
+++ b/srcs/data/django/main/models.py
@@ -28,6 +28,25 @@ class CustomUser(AbstractUser):
         friend_request.save()
         return friend_request
 
+    @property
+    def wins(self):
+        return Matchmaking.objects.filter(winner=self).count()
+
+    @property
+    def losses(self):
+        return Matchmaking.objects.filter(
+            Q(user1=self) | Q(user2=self),
+            ~Q(winner=self),
+            winner__isnull=False
+        ).count()
+
+    @property
+    def win_rate(self):
+        total_matches = self.wins + self.losses
+        if total_matches > 0:
+            return int((self.wins / total_matches) * 100)
+        return 0
+
 class Image(models.Model):
     image = models.ImageField(upload_to='avatars/', validators=[validate_file_size])
 

--- a/srcs/data/django/main/static/translations/en.json
+++ b/srcs/data/django/main/static/translations/en.json
@@ -215,5 +215,11 @@
     "history_tournament_paddle_size": "Paddle Size",
     "history_tournament_paddle_normal": "Normal",
     "history_tournament_paddle_small": "Small",
-    "history_tournament_paddle_large": "Large"
+    "history_tournament_paddle_large": "Large",
+    "match_history_button": "All Users' Stats",
+    "game_stats_header": "All Users' Stats",
+    "game_stats_user": "User",
+    "game_stats_wins": "Wins",
+    "game_stats_losses": "Losses",
+    "game_stats_win_rate": "Win Rate(%)"
 }

--- a/srcs/data/django/main/static/translations/ja.json
+++ b/srcs/data/django/main/static/translations/ja.json
@@ -215,6 +215,11 @@
     "history_tournament_paddle_size": "パドルサイズ",
     "history_tournament_paddle_normal": "標準",
     "history_tournament_paddle_small": "小さい",
-    "history_tournament_paddle_large": "大きい"
-    
+    "history_tournament_paddle_large": "大きい",
+    "match_history_button": "全てのユーザーの成績",
+    "game_stats_header": "全てのユーザーの成績",
+    "game_stats_user": "ユーザー",
+    "game_stats_wins": "勝ち",
+    "game_stats_losses": "負け",
+    "game_stats_win_rate": "勝率(%)"
 }

--- a/srcs/data/django/main/static/translations/kr.json
+++ b/srcs/data/django/main/static/translations/kr.json
@@ -215,5 +215,11 @@
     "history_tournament_paddle_size": "패들 사이즈",
     "history_tournament_paddle_normal": "표준",
     "history_tournament_paddle_small": "작다",
-    "history_tournament_paddle_large": "크다"
+    "history_tournament_paddle_large": "크다",
+    "match_history_button": "모든 유저의 성적",
+    "game_stats_header": "모든 유저의 성적",
+    "game_stats_user": "유저",
+    "game_stats_wins": "승리",
+    "game_stats_losses": "패배",
+    "game_stats_win_rate": "승률(%)"
 }

--- a/srcs/data/django/main/templates/game_stats.html
+++ b/srcs/data/django/main/templates/game_stats.html
@@ -1,0 +1,25 @@
+<div class="px-5">
+    <h1 class="mb-3 translations" id="game_stats_header">　</h1>
+    <table class="table-dark table">
+        <thead>
+            <tr>
+                <th scope="col" class="translations text-nowrap" id="game_stats_user">　</th>
+                <th scope="col" class="translations text-nowrap" id="game_stats_wins">　</th>
+                <th scope="col" class="translations text-nowrap" id="game_stats_losses">　</th>
+                <th scope="col" class="translations text-nowrap" id="game_stats_win_rate">　</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+            <tr>
+                <td class="text-nowrap">
+                    <a href="#" class="btn btn-primary btn-sm post-link btn-custom translations text-nowrap" data_url="process-post/" page="match_history" user_id="{{ user.id }}" style="width: 6rem;">{{ user.display_name }}</a>
+                </td>
+                <td class="text-nowrap">{{ user.wins }}</td>
+                <td class="text-nowrap">{{ user.losses }}</td>
+                <td class="text-nowrap">{{ user.win_rate }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/srcs/data/django/main/templates/match_history.html
+++ b/srcs/data/django/main/templates/match_history.html
@@ -97,4 +97,5 @@
                 {% endif %}
             {% endfor %}
     </table>
+    <a href="#" class="btn btn-primary post-link translations" data_url="process-post/" page="game_stats" title="Edit Profile" id="match_history_button">　</a>
 </div>

--- a/srcs/data/django/main/templates/profile.html
+++ b/srcs/data/django/main/templates/profile.html
@@ -21,7 +21,7 @@
                     <p class="card-text">{{ loss }}</p>
                     <h5 class="card-title translations mt-3" id="profile_win_rate">　</h5>
                     <p class="card-text">{{ win_rate }}%</p>
-                    <a href="#" class="btn btn-primary card-link post-link translations" data_url="process-post/" page="match_history" title="Edit Profile" id="profile_button2">　</a>
+                    <a href="#" class="btn btn-primary card-link post-link translations" data_url="process-post/" page="match_history" title="match history" id="profile_button2">　</a>
                 </div>
             </div>
         </div>

--- a/srcs/data/django/main/views.py
+++ b/srcs/data/django/main/views.py
@@ -754,6 +754,10 @@ def process_post_data(request):
             elif page == 'match_history':
                 user = request.user
                 if user.is_authenticated:
+                    user_id = post_data.get('user_id')
+                    if user_id:
+                        user = CustomUser.objects.filter(id=user_id).first()
+                        # logger.debug(f'user: {user}') 
                     matches = Matchmaking.objects.filter(is_single=False).exclude(winner__isnull=True)
                     tournaments = Tournament.objects.filter(size=F('num_users'))
                     tournament_users = TournamentUser.objects.filter(is_complete=True)
@@ -898,6 +902,15 @@ def process_post_data(request):
                     'timeout' : '10000',
                     'alert': '参加者を待っています',
                 }
+            elif page == 'game_stats':
+                user = request.user
+                if user.is_authenticated:
+                    users = CustomUser.objects.exclude(display_name__isnull=True)
+                    response_data = {
+                        'page': page,
+                        'content': render_to_string('game_stats.html', {'users': users}),
+                        'title': 'game stats',
+                    }
 
 
             else:


### PR DESCRIPTION
```
Each user has a Match History including 1v1 games, dates, and relevant
details, accessible to logged-in users.
```
に対応しました。

マッチヒストリーというページの一番下に全てのユーザーの成績というボタンがあり、そこから他のユーザーの勝率等見れるようにしました。
その一覧の右側がユーザーのdisplay nameのボタンになっていて、その人の詳しい成績が見れます。
