### PR TITLE
Single Commandによるスタートについて（要議論）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build:
 
 up: build
 	docker compose -f $(DOCKER_COMPOSE_YML) up -d
+	docker exec -it django4242 python manage.py migrate
 #	chmod -R 777 ./srcs/data/postgres
 
 stop:

--- a/srcs/requirements/django/tools/entrypoint.sh
+++ b/srcs/requirements/django/tools/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 
 # エントリーポイントスクリプト (entrypoint.sh)
 # データベースマイグレーションの適用
-python manage.py makemigrations
-python manage.py migrate
+# python manage.py makemigrations
+# python manage.py migrate
 
 # 静的ファイルの収集
 #python manage.py collectstatic --noinput


### PR DESCRIPTION
https://github.com/ilovenoah/ft_transcendence/issues/53
についてです
とりあえずは Makefile の up ターゲットに
docker exec -it django4242 python manage.py migrate
を追加したので、
make up
すればDBのmigrationまで終了して、正常に立ち上がります

課題文の例には
```
Everything must be launched with a single command line to run an autonomous
container provided by Docker . Example : docker-compose up --build
```
とありますが、make up で docker composeを呼んでいるので
これで問題ないと思いますが、いかがでしょうか

